### PR TITLE
Add Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+# A sample Gemfile
+source "https://rubygems.org"
+
+gem "gemoji"


### PR DESCRIPTION
実はmikutterでは
 https://github.com/mikutter/mikutter/blob/master/Gemfile#L30-lL35 にあるように`core/plugin/*/Gemfile` と `~/.mikutter/plugin/*/Gemfile` にGemfileが置けて bundle installで一括で依存ライブラリを置けます。
なのでプラグインがGemfileを持って依存gemを管理しても良さそうです。
いかがでしょう？
