### PR TITLE
Post時に{:message => text } のアレがそのままつく問題を修正

### DIFF
--- a/mikutter_emoji.rb
+++ b/mikutter_emoji.rb
@@ -17,7 +17,7 @@ Plugin.create(:emoji) do
         end
       end
     end
-    Service.primary.post :message => text
+    Service.primary.post text
     Plugin.call(:before_postbox_text, text)
     Plugin.create(:gtk).widgetof(gui_postbox).widget_post.buffer.text=''
     Plugin.filter_cancel!


### PR DESCRIPTION
mikutter 3.7にて投稿しようとしたところ以下のようになったことに関しての修正です。
https://knzk.me/@kazu0617/100648858122758631
（Ruby的に直し方としてOKなのか・・・？）